### PR TITLE
new feature: fine control over which dates are enabled/disabled

### DIFF
--- a/Material.Blazor.Website/Pages/DatePicker.razor
+++ b/Material.Blazor.Website/Pages/DatePicker.razor
@@ -65,6 +65,31 @@
                 </Primary>
             </MBCard>
         </div>
+
+        <div class="mdc-layout-grid__cell--span-4">
+            <MBCard AutoStyled="true">
+                <Primary>
+                    <h2 class="mb-card__title mdc-typography mdc-typography--headline6">
+                        Selectable dates
+                    </h2>
+
+                    <h3 class="mb-card__subtitle mdc-typography mdc-typography--subtitle2">
+                        Control which dates are selectable.
+                    </h3>
+
+                    <p>
+                        <MBDatePicker @bind-Value="@Outlined"
+                                      Label="Weekdays Outlined"
+                                      DateFormat="ddd MMM dd, yyyy"
+                                      DateIsSelectable="(date) => date.DayOfWeek is DayOfWeek.Monday or DayOfWeek.Wednesday or DayOfWeek.Friday or DayOfWeek.Sunday"
+                                      SelectInputStyle="MBSelectInputStyle.Outlined"
+                                      MaxDate="@Max"
+                                      MenuSurfacePositioning="@MBMenuSurfacePositioning.Fixed"
+                                      MinDate="@Min" />
+                    </p>
+                </Primary>
+            </MBCard>
+        </div>
     </PageContent>
 </DemonstrationPage>
 

--- a/Material.Blazor/Components/DatePicker/InternalDatePickerDayButton.razor.cs
+++ b/Material.Blazor/Components/DatePicker/InternalDatePickerDayButton.razor.cs
@@ -40,6 +40,10 @@ namespace Material.Blazor.Internal
         /// </summary>
         [Parameter] public MBDateSelectionCriteria? DateSelectionCriteria { get; set; }
 
+        /// <summary>
+        /// Control whether a date is selectable by evaluating the method.
+        /// </summary>
+        [Parameter] public Func<DateTime, bool>? DateIsSelectable { get; set; }
 
         /// <summary>
         /// Minimum date set by the consumer
@@ -62,6 +66,11 @@ namespace Material.Blazor.Internal
             get
             {
                 if (DisplayDate.Month != StartOfDisplayMonth.Month)
+                {
+                    return true;
+                }
+
+                if (DateIsSelectable != null && DateIsSelectable != MBDatePicker.DateIsSelectableNotUsed && !DateIsSelectable(DisplayDate))
                 {
                     return true;
                 }

--- a/Material.Blazor/Components/DatePicker/InternalDatePickerPanel.razor
+++ b/Material.Blazor/Components/DatePicker/InternalDatePickerPanel.razor
@@ -36,7 +36,7 @@
         <div class="mb-dp-year-pad">
             @foreach (var year in Years)
             {
-                <InternalDatePickerYearButton @key="@year" CurrentYear="@StartOfDisplayMonth.Year" DisplayYear="@year" OnItemClickAsync="@OnYearItemClick" MinDate="@MinDate" MaxDate="@MaxDate" CurrentYearId="@currentYearId" />
+                <InternalDatePickerYearButton @key="@year" CurrentYear="@StartOfDisplayMonth.Year" DisplayYear="@year" OnItemClickAsync="@OnYearItemClick" MinDate="@MinDate" MaxDate="@MaxDate" CurrentYearId="@currentYearId" DateIsSelectable="@DateIsSelectable" />
             }
         </div>
     }
@@ -52,7 +52,7 @@
             <div class="mdc-list mb-dp-day-pad__days-block">
                 @foreach (var date in Dates)
                 {
-                    <InternalDatePickerDayButton @key="@date" DateSelectionCriteria="@DateSelectionCriteria" CurrentDate="@ComponentValue" DisplayDate="@date" StartOfDisplayMonth="@StartOfDisplayMonth" OnItemClickAsync="@OnDayItemClickAsync" MinDate="@MinDate" MaxDate="@MaxDate" />
+                    <InternalDatePickerDayButton @key="@date" DateSelectionCriteria="@DateSelectionCriteria" DateIsSelectable="@DateIsSelectable" CurrentDate="@ComponentValue" DisplayDate="@date" StartOfDisplayMonth="@StartOfDisplayMonth" OnItemClickAsync="@OnDayItemClickAsync" MinDate="@MinDate" MaxDate="@MaxDate" />
                 }
             </div>
         </div>

--- a/Material.Blazor/Components/DatePicker/InternalDatePickerPanel.razor.cs
+++ b/Material.Blazor/Components/DatePicker/InternalDatePickerPanel.razor.cs
@@ -69,9 +69,9 @@ namespace Material.Blazor.Internal
             }
         }
 
-        private LinkedList<DateTime> Dates { get; set; } = new LinkedList<DateTime>();
+        private List<DateTime> Dates { get; set; } = new List<DateTime>();
 
-        private LinkedList<int> Years { get; set; } = new LinkedList<int>();
+        private List<int> Years { get; set; } = new List<int>();
 
         private DateTime InitialDate { get; set; }
 
@@ -89,8 +89,6 @@ namespace Material.Blazor.Internal
 
         private string MonthText => StartOfDisplayMonth.ToString("MMMM yyyy");
 
-        private int Year => StartOfDisplayMonth.Year;
-
         private bool IsFirstParametersSet { get; set; } = true;
 
 
@@ -107,7 +105,12 @@ namespace Material.Blazor.Internal
             ClassMapperInstance
                 .Add("mdc-typography--body2 mb-dp-container");
 
-            DaysOfWeek = (new DateTimeFormatInfo()).DayNames.Select(d => d.Substring(0, 1)).ToArray();
+            DaysOfWeek = CultureInfo.CurrentCulture.DateTimeFormat.AbbreviatedDayNames;
+            var rotate_by = (int)CultureInfo.CurrentCulture.DateTimeFormat.FirstDayOfWeek;
+            if (rotate_by > 0)
+            {
+                DaysOfWeek = DaysOfWeek.Skip(rotate_by).Concat(DaysOfWeek.Take(rotate_by)).ToArray();
+            }
 
             ForceShouldRenderToTrue = true;
         }
@@ -141,26 +144,24 @@ namespace Material.Blazor.Internal
                 CachedMaxDate = MaxDate;
 
                 var startDate = StartOfDisplayMonth = new DateTime(ComponentValue.Year, ComponentValue.Month, 1).AddMonths(MonthsOffset);
-                var endDate = startDate.AddMonths(1).AddDays(-1);
+                startDate = startDate.AddDays(1-(int)CultureInfo.CurrentCulture.DateTimeFormat.FirstDayOfWeek);
+                var endDate = startDate.AddDays(6 * 7); // 6 lines of 7 days each
 
-                startDate = startDate.AddDays(-Convert.ToInt32(startDate.DayOfWeek));
-                endDate = endDate.AddDays(-Convert.ToInt32(endDate.DayOfWeek) + 7);
-
-                Dates = new LinkedList<DateTime>();
+                Dates = new List<DateTime>();
 
                 for (var date = startDate; date < endDate; date = date.AddDays(1))
                 {
-                    Dates.AddLast(date);
+                    Dates.Add(date);
                 }
 
                 var startYear = ((MinDate.Year - 1) / 4) * 4 + 1;
                 var endYear = ((MaxDate.Year + 3) / 4) * 4 + 1;
 
-                Years = new LinkedList<int>();
+                Years = new List<int>();
 
                 for (var year = startYear; year < endYear; year++)
                 {
-                    Years.AddLast(year);
+                    Years.Add(year);
                 }
 
                 ShowYearPad = false;

--- a/Material.Blazor/Components/DatePicker/InternalDatePickerPanel.razor.cs
+++ b/Material.Blazor/Components/DatePicker/InternalDatePickerPanel.razor.cs
@@ -21,6 +21,12 @@ namespace Material.Blazor.Internal
 
 
         /// <summary>
+        /// Control whether a date is selectable by evaluating the method.
+        /// </summary>
+        [Parameter] public Func<DateTime, bool>? DateIsSelectable { get; set; }
+
+
+        /// <summary>
         /// Minimum date set by the consumer
         /// </summary>
         [Parameter] public DateTime MinDate { get; set; }

--- a/Material.Blazor/Components/DatePicker/InternalDatePickerPanel.razor.cs
+++ b/Material.Blazor/Components/DatePicker/InternalDatePickerPanel.razor.cs
@@ -142,9 +142,11 @@ namespace Material.Blazor.Internal
                 CachedComponentValue = ComponentValue;
                 CachedMinDate = MinDate;
                 CachedMaxDate = MaxDate;
-
                 var startDate = StartOfDisplayMonth = new DateTime(ComponentValue.Year, ComponentValue.Month, 1).AddMonths(MonthsOffset);
-                startDate = startDate.AddDays(1-(int)CultureInfo.CurrentCulture.DateTimeFormat.FirstDayOfWeek);
+                while (startDate.DayOfWeek != CultureInfo.CurrentCulture.DateTimeFormat.FirstDayOfWeek)
+                {
+                    startDate = startDate.AddDays(-1);
+                }
                 var endDate = startDate.AddDays(6 * 7); // 6 lines of 7 days each
 
                 Dates = new List<DateTime>();

--- a/Material.Blazor/Components/DatePicker/MBDatePicker.razor
+++ b/Material.Blazor/Components/DatePicker/MBDatePicker.razor
@@ -69,6 +69,7 @@
         <InternalDatePickerPanel @ref="Panel"
                                  @bind-Value="@ComponentValue"
                                  DateSelectionCriteria="@DateSelectionCriteria"
+                                 DateIsSelectable="@DateIsSelectable"
                                  MinDate="@MinDate"
                                  MaxDate="@MaxDate"
                                  DateFormat="@DateFormat" />

--- a/Material.Blazor/Components/DatePicker/MBDatePicker.razor.cs
+++ b/Material.Blazor/Components/DatePicker/MBDatePicker.razor.cs
@@ -26,11 +26,17 @@ namespace Material.Blazor
         /// </summary>
         [Parameter] public string Label { get; set; }
 
-
         /// <summary>
         /// Date selection criteria
         /// </summary>
         [Parameter] public MBDateSelectionCriteria? DateSelectionCriteria { get; set; }
+
+
+        internal static readonly Func<DateTime, bool> DateIsSelectableNotUsed = (_) => true;
+        /// <summary>
+        /// Control whether a date is selectable by evaluating the method.
+        /// </summary>
+        [Parameter] public Func<DateTime, bool>? DateIsSelectable { get; set; } = DateIsSelectableNotUsed;
 
 
         /// <summary>


### PR DESCRIPTION
Hi guys,

I found the options for how dates in a date picker are selectable to be lacking flexibility for my use case. This feature gives full control over this to the user. I also added a demo card to show how it can be used.

This works in addition to the existing features and is disabled by default, so it doesn't break any existing usage.

Stefan