### PR TITLE
new feature: allow custom values for auto-complete

### DIFF
--- a/Material.Blazor.Website/Pages/AutocompleteTextField.razor
+++ b/Material.Blazor.Website/Pages/AutocompleteTextField.razor
@@ -55,6 +55,23 @@
                 </Primary>
             </MBCard>
         </div>
+
+
+        <div class="mdc-layout-grid__cell--span-4">
+            <MBCard AutoStyled="true">
+                <Primary>
+                    <h2 class="mb-card__title mdc-typography mdc-typography--headline6">
+                        Allow custom value
+                    </h2>
+
+                    <h3 class="mb-card__subtitle mdc-typography mdc-typography--subtitle2">
+                        The auto-complete items may only be suggestions, but custom values may be permitted.
+                    </h3>
+
+                    <p><MBAutocompleteTextField Label="Any value is valid" @bind-Value="@CustomValue" SelectItems="@Fruits" AllowCustomValue="true" /></p>
+                </Primary>
+            </MBCard>
+        </div>
     </PageContent>
 </DemonstrationPage>
 
@@ -112,6 +129,19 @@
             _popupHelperText = value;
 
             ToastService.ShowToast(heading: "Popup Helper Text", message: $"Value: '{_popupHelperText}'", level: MBToastLevel.Success, showIcon: false);
+        }
+    }
+
+
+    private string _customValue = "Customberry";
+    private string CustomValue
+    {
+        get => _customValue;
+        set
+        {
+            _customValue = value;
+
+            ToastService.ShowToast(heading: "Custom Value", message: $"Value: '{_customValue}'", level: MBToastLevel.Success, showIcon: false);
         }
     }
 

--- a/Material.Blazor.Website/Pages/AutocompleteTextField.razor
+++ b/Material.Blazor.Website/Pages/AutocompleteTextField.razor
@@ -68,6 +68,12 @@
                         The auto-complete items may only be suggestions, but custom values may be permitted.
                     </h3>
 
+                    <style>
+                        li.mb-autocomplete-custom-value + li {
+                            border-top: 1px solid darkgray;
+                        }
+                    </style>
+
                     <p><MBAutocompleteTextField Label="Any value is valid" @bind-Value="@CustomValue" SelectItems="@Fruits" AllowCustomValue="true" /></p>
                 </Primary>
             </MBCard>

--- a/Material.Blazor/Components/AutocompleteTextField/MBAutocompleteTextField.razor
+++ b/Material.Blazor/Components/AutocompleteTextField/MBAutocompleteTextField.razor
@@ -23,15 +23,30 @@
 
     <div class="mdc-menu-surface--anchor">
         <div @ref="@MenuReference"
-                class="mdc-menu mdc-menu-surface mdc-menu-surface--fixed"
-                @onfocusin="OnMenuFocusIn"
-                @onfocusout="OnMenuFocusOut"
-                tabindex="-1">
+             class="mdc-menu mdc-menu-surface mdc-menu-surface--fixed"
+             @onfocusin="OnMenuFocusIn"
+             @onfocusout="OnMenuFocusOut"
+             tabindex="-1">
 
             <ul class="mdc-list"
                 tabindex="-1">
 
-                @foreach (var item in SelectInfo.SelectList)
+                @if (SelectInfo.FirstValueIsCustomValue)
+                {
+                    var item = SelectInfo.SelectList.First();
+                    var listClass = "mdc-list-item mb-autocomplete-custom-value";
+                    var ariaSelected = SelectInfo.SelectList.Length == 1;
+                    <li @key="@item"
+                        class="@listClass"
+                        data-value="@item"
+                        aria-selected="@ariaSelected"
+                        role="option"
+                        tabindex="0">
+                        <span class="mdc-list-item__ripple"></span>
+                        <span class="mdc-list-item__text mb-full-width">@item</span>
+                    </li>
+                }
+                @foreach (var item in SelectInfo.SelectList.Skip(SelectInfo.FirstValueIsCustomValue ? 1 : 0))
                 {
                     var listClass = "mdc-list-item" + (item.Equals(Value) ? " mdc-list-item--selected" : "");
                     var ariaSelected = item.Equals(Value);

--- a/Material.Blazor/Components/AutocompleteTextField/MBAutocompleteTextField.razor.cs
+++ b/Material.Blazor/Components/AutocompleteTextField/MBAutocompleteTextField.razor.cs
@@ -1,6 +1,5 @@
 ﻿using Material.Blazor.Internal;
 using Microsoft.AspNetCore.Components;
-using Microsoft.AspNetCore.Components.Forms;
 using Microsoft.JSInterop;
 using System;
 using System.Collections.Generic;
@@ -23,9 +22,10 @@ namespace Material.Blazor
         private class SelectionInfo
         {
             public string SelectedText { get; set; }
-            public IEnumerable<string> SelectList { get; set; }
+            public string[] SelectList { get; set; }
+            public bool FirstValueIsCustomValue { get; set; }
             public bool PotentialMatchesFound => SelectList.Any();
-            public bool FullMatchFound => (SelectList.Count() == 1) && SelectList.Contains(SelectedText);
+            public bool FullMatchFound => (SelectList.Length == 1) && SelectList.Contains(SelectedText);
         }
 
 
@@ -127,8 +127,8 @@ namespace Material.Blazor
         /// <summary>
         /// List of items to select from.
         /// </summary>
-        [Parameter] public IEnumerable<string> SelectItems 
-        { 
+        [Parameter] public IEnumerable<string> SelectItems
+        {
             get => selectItems;
             set
             {
@@ -143,6 +143,11 @@ namespace Material.Blazor
             }
         }
 #nullable restore annotations
+
+        /// <summary>
+        /// When set, the value that the user enters does not have to match any of the selectable items.
+        /// </summary>
+        [Parameter] public bool AllowCustomValue { get; set; }
 
 
         private bool IsOpen { get; set; } = false;
@@ -235,11 +240,17 @@ namespace Material.Blazor
             var partialMatches = (from f in MySelectItems
                                   where partialMatchRegex.Matches(f.SearchTarget).Count > 0
                                   select f.Item).ToArray();
+            bool firstValueIsCustomValue = AllowCustomValue && fieldText != null && !partialMatches.Contains(fieldText);
+            if (firstValueIsCustomValue)
+            {
+                partialMatches = partialMatches.Prepend(fieldText).ToArray();
+            }
 
             return new SelectionInfo()
             {
                 SelectedText = fieldText,
-                SelectList = partialMatches
+                SelectList = partialMatches,
+                FirstValueIsCustomValue = firstValueIsCustomValue
             };
         }
 


### PR DESCRIPTION
This is a new feature for AutocompleteTextField.

By setting the `AllowCustomValue` boolean to true, any user input becomes acceptable. The value is displayed at the top of the list. It has the extra css class `mb-autocomplete-custom-value` such that users can customise the style of that entry (e.g. by adding a divider after it or making it italic or making it bold or anything else). The demo shows that by applying a divider.