### PR TITLE
all interfaces should be public to be mockable

### DIFF
--- a/Material.Blazor/Model/Interfaces/IMBDialog.cs
+++ b/Material.Blazor/Model/Interfaces/IMBDialog.cs
@@ -4,7 +4,7 @@
     /// An interface implemented by <see cref="MBDialog"/> to allow child components to
     /// register themselves for Material Theme js instantiation.
     /// </summary>
-    internal interface IMBDialog
+    public interface IMBDialog
     {
         /// <summary>
         /// The child component should implement <see cref="DialogChildComponent"/> and call this when running <see cref="Microsoft.AspNetCore.Components.Componentbase.OnInitialized()"/>

--- a/Material.Blazor/Model/Tooltip/IMBTooltipService.cs
+++ b/Material.Blazor/Model/Tooltip/IMBTooltipService.cs
@@ -14,7 +14,7 @@ namespace Material.Blazor
     /// is called without an <see cref="MBTooltipAnchor"/> component used in the app.
     /// </para>
     /// </summary>
-    internal interface IMBTooltipService
+    public interface IMBTooltipService
     {
         /// <summary>
         /// A event that will be invoked when adding a tooltip


### PR DESCRIPTION
Trivial change: mocking requires interfaces to be public.